### PR TITLE
Bluetoothのペアリング関数とボタンを作成

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
+    <uses-permission android:name="android.permission.BLUETOOTH"/>
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/myapplicationui1/ui/theme/activity_explanation.kt
+++ b/app/src/main/java/com/example/myapplicationui1/ui/theme/activity_explanation.kt
@@ -1,11 +1,18 @@
 package com.example.myapplicationui1
 
+import android.bluetooth.BluetoothAdapter
+import android.bluetooth.BluetoothManager
 import android.content.Intent
+import android.os.Build
+import android.os.Build.VERSION
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.widget.Button
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
 
 class ExplanationActivity : AppCompatActivity() {
+    private var btPermission = false;
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -13,6 +20,7 @@ class ExplanationActivity : AppCompatActivity() {
 
         val yesButton: Button = findViewById(R.id.yes_button)
         val noButton: Button = findViewById(R.id.no_button)
+        val connectButton: Button = findViewById(R.id.connect_button)
 
         // 「はい」ボタンがクリックされた時、activity_controller_explanation_selection へ遷移
         yesButton.setOnClickListener {
@@ -25,5 +33,52 @@ class ExplanationActivity : AppCompatActivity() {
             val intent = Intent(this, ControllerSelectionActivity::class.java)
             startActivity(intent)
         }
+
+        connectButton.setOnClickListener {
+            scanBt()
+        }
     }
+
+    fun scanBt() {
+        val bluetoothManager: BluetoothManager = getSystemService(BluetoothManager::class.java)
+        val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
+
+        if(bluetoothAdapter == null) {
+            Toast.makeText(this, "Bluetooth接続が許可されていません", Toast.LENGTH_LONG).show()
+        } else {
+            if(VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                blueToothPermissionLauncher.launch(android.Manifest.permission.BLUETOOTH_CONNECT)
+            } else {
+                blueToothPermissionLauncher.launch(android.Manifest.permission.BLUETOOTH)
+            }
+        }
+    }
+
+    private val blueToothPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) {
+            isGranted: Boolean ->
+        if(isGranted) {
+            val bluetoothManager: BluetoothManager = getSystemService(BluetoothManager::class.java)
+            val bluetoothAdapter: BluetoothAdapter? = bluetoothManager.adapter
+            btPermission = true
+
+            if(bluetoothAdapter?.isEnabled == false) {
+                val enableBtIntent = Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE)
+                btActivityResultLauncher.launch(enableBtIntent)
+            } else {
+                canBtScanComment()
+            }
+        } else {
+            btPermission = false
+        }
+    }
+    private val btActivityResultLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) {
+        if(it.resultCode == RESULT_OK) {
+            canBtScanComment()
+        }
+    }
+    private fun canBtScanComment() = Toast.makeText(this, "Bluetooth接続が可能です", Toast.LENGTH_LONG).show()
 }

--- a/app/src/main/res/layout/activity_explanation.xml
+++ b/app/src/main/res/layout/activity_explanation.xml
@@ -23,4 +23,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="いいえ" />
+
+    <Button
+        android:id="@+id/connect_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Scan"/>
 </LinearLayout>


### PR DESCRIPTION
- activity-selection.ktにボタンを押すとペアリングをする処理を追加
- まだアンドロイド実機で検証してない